### PR TITLE
Hide auth window on successful login

### DIFF
--- a/client_ready/main.cpp
+++ b/client_ready/main.cpp
@@ -1,4 +1,5 @@
 #include "reg_and_auth.h"
+#include "mainwindow.h"
 #include <QApplication>
 
 int main(int argc, char *argv[])
@@ -6,7 +7,11 @@ int main(int argc, char *argv[])
     QApplication a(argc, argv);
 
     RegAndAuth w;
+    mainwindow mainWin;
+    w.setmainwindow(&mainWin);
     w.show();
+
+    // Главное окно задач покажем после успешной авторизации
 
     return a.exec();
 }

--- a/client_ready/reg_and_auth.cpp
+++ b/client_ready/reg_and_auth.cpp
@@ -1,10 +1,12 @@
 #include "reg_and_auth.h"
 #include "ui_reg_and_auth.h"
 #include "client.h"
+#include "mainwindow.h"
 
 RegAndAuth::RegAndAuth(QWidget *parent) :
     QWidget(parent),
-    ui(new Ui::RegAndAuth)
+    ui(new Ui::RegAndAuth),
+    m_mainWindow(nullptr)
 {
     ui->setupUi(this);
 
@@ -21,6 +23,11 @@ RegAndAuth::RegAndAuth(QWidget *parent) :
 RegAndAuth::~RegAndAuth()
 {
     delete ui;
+}
+
+void RegAndAuth::setmainwindow(mainwindow *w)
+{
+    m_mainWindow = w;
 }
 
 // Показать форму регистрации, скрыть форму входа
@@ -96,9 +103,10 @@ void RegAndAuth::onServerResponse(const QString &response)
     // Ответы для авторизации
     else if (response.startsWith("AUTH_OK")) {
         ui->logResultLabel->setText(response);
-        // Успешный вход: можно перейти к окну задач (например, вызвать другой виджет)
-        // Тут просто можно скрыть всю форму или отображать сообщение:
-        // Например: ui->logResultLabel->setText(response + ". Выполнен вход.");
+        if (m_mainWindow) {
+            this->hide();
+            m_mainWindow->show();
+        }
     }
     else if (response.startsWith("AUTH_ERR")) {
         ui->logResultLabel->setText(response);


### PR DESCRIPTION
## Summary
- wire up the optional tools window
- hide the login dialog after a successful "AUTH_OK" response

## Testing
- `qmake` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841523b9d308328af74d51aa80deff8